### PR TITLE
Enable variable domain/ressource assignment

### DIFF
--- a/jsxc.lib.js
+++ b/jsxc.lib.js
@@ -289,6 +289,9 @@ var jsxc;
                if (typeof jsxc.options.loginForm.preJid === 'function') {
                   jid = jsxc.options.loginForm.preJid(jid);
                }
+               if (typeof settings.xmpp.tuneJid === 'function') {
+                  jid = settings.xmpp.tuneJid(jid);
+               }
 
                jsxc.cid = jsxc.jidToCid(jid);
 


### PR DESCRIPTION
# Support for flexible domains

A new optional function in the configuration settings will allow you to
support multiple domains or other translations between the login name
and the JID.
