### PR TITLE
Show avatar also by EXTVAL (url), not only by BINVAL

### DIFF
--- a/jsxc.lib.js
+++ b/jsxc.lib.js
@@ -1027,7 +1027,7 @@ var jsxc;
                if (vCard.length === 0) {
                   jsxc.debug('No photo provided');
                   src = 0;
-               } if(vCard.find('EXTVAL').length > 0){
+               } else if(vCard.find('EXTVAL').length > 0){
                   src = vCard.find('EXTVAL').text();
                } else {
                   var img = vCard.find('BINVAL').text();


### PR DESCRIPTION
Many sites have already the user avatar url, and in such case it’s good
to use just url, not to generate and store another blob.
