### PR TITLE
Fixed broken grunt dataUri task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,7 @@ module.exports = function(grunt) {
           options: {
             target: ['img/*.*', 'img/**/*.*'],
             fixDirLevel: true,
-            baseDir: './'
+            baseDir: './build'
           }
         }
       },
@@ -200,7 +200,7 @@ module.exports = function(grunt) {
    grunt.registerTask('build', [ 'search:changelog', 'pre', 'jsdoc' ]);
 
    // Create alpha/beta build
-   grunt.registerTask('pre', [ 'jshint', 'search:console', 'clean', 'css', 'dataUri', 'copy', 'usebanner', 'replace', 'concat', 'uglify', 'compress' ]);
+   grunt.registerTask('pre', [ 'jshint', 'search:console', 'clean', 'css', 'copy', 'dataUri', 'usebanner', 'replace', 'concat', 'uglify', 'compress' ]);
 
    // before commit
    grunt.registerTask('commit', [ 'jshint', 'search:console' ]);


### PR DESCRIPTION
In `build/css/<file>` you are pointing to `../img/<file>` so we have to set the `baseDir` to the build directory otherwise grunt will not find the images! Also we have to wait for the grunt-copy-task. Before that `build` does not exist.