### PR TITLE
Update jsxc*.js <script src= location in ./example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -22,9 +22,8 @@
 	  <script src="../build/lib/jquery.fullscreen.js"></script>
 	 
 	  <script src="../build/lib/jsxc.dep.js"></script>
-	  <script src="../build/jsxc.lib.js"></script>
-	  <script src="../build/jsxc.lib.webrtc.js"></script>
-	  
+	  <script src="../build/jsxc.min.js"></script>
+
 	  <script src="js/example.js"></script>
 
 	</head>

--- a/example/login.html
+++ b/example/login.html
@@ -22,8 +22,7 @@
 	 <script src="../build/lib/jquery.fullscreen.js"></script>
 	 
 	 <script src="../build/lib/jsxc.dep.js"></script>
-	 <script src="../build/jsxc.lib.js"></script>
-	 <script src="../build/jsxc.lib.webrtc.js"></script>
+	 <script src="../build/jsxc.min.js"></script>
      
      <script src="js/example.js"></script>
 


### PR DESCRIPTION
Greetings, Klaus. Please forgive me if I overlooked something in the directory design, but in my experience, the currently given locations of jsxc*.js in ./example/*.html are incorrect and as a result, the examples will not work without this patch.