### PR TITLE
Fixed Bug in checking the last Activity

### DIFF
--- a/src/jsxc.lib.js
+++ b/src/jsxc.lib.js
@@ -243,7 +243,7 @@ jsxc = {
 
       var lastActivity = jsxc.storage.getItem('lastActivity') || 0;
 
-      if ((new Date()).getTime() - lastActivity < jsxc.options.loginTimeout) {
+      if ((new Date()).getTime() - lastActivity > jsxc.options.loginTimeout) {
          jsxc.restore = true;
       }
 


### PR DESCRIPTION
This is a fix for a bug which was filed here: https://github.com/diaspora/jsxc/issues/89
The bug was in line 246, the time check are wrong. It has to be an '<' instead of an '>'.
I saw that the bug is in this repo too so here is the fix for it.