### PR TITLE
Remove maxBytes restriction from dataUri task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,8 +203,7 @@ module.exports = function(grunt) {
             dest: '<%= target %>/css/',
             options: {
                target: ['<%= target %>/img/*.*', '<%= target %>/img/**/*.*'],
-               fixDirLevel: false,
-               maxBytes: 2048
+               fixDirLevel: false
             }
          }
       },


### PR DESCRIPTION
Currently there are multiple files which are larger then the current limit.