### PR TITLE
Jsxc does not distinguish between groups

### DIFF
--- a/src/jsxc.lib.xmpp.js
+++ b/src/jsxc.lib.xmpp.js
@@ -490,6 +490,10 @@ jsxc.xmpp = {
          var bid = jsxc.jidToBid(jid);
          var sub = $(this).attr('subscription');
 
+         // jsxc does not distinguish between groups
+         // therefore we should check on duplicates
+         if ($.inArray(bid, buddies) != -1) { return; }
+
          buddies.push(bid);
 
          jsxc.storage.removeUserItem('res', bid);


### PR DESCRIPTION
related to diaspora/jsxc#89
related to diaspora/jsxc#117

we have duplicates in our contact list cause of the same user in multiple groups.
![untitled](https://cloud.githubusercontent.com/assets/652428/9369683/23d52106-46cb-11e5-9941-0d92e8acb731.png)

do you want this change in upstream too or do you plan on implementing group categorization in future?