### PR TITLE
Use crendential when performing turn credential ajax crossdomain call.

### DIFF
--- a/src/jsxc.lib.options.js
+++ b/src/jsxc.lib.options.js
@@ -223,6 +223,9 @@ jsxc.options = {
       /** [optional] If set, jsxc requests and uses RTCPeerConfig from this url */
       url: null,
 
+      /** If true, jsxc send cookies when requesting RTCPeerConfig from the url above */
+      withCredentials: false,
+
       /** ICE servers like defined in http://www.w3.org/TR/webrtc/#idl-def-RTCIceServer */
       iceServers: [{
          urls: 'stun:stun.stunprotocol.org'

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -134,7 +134,7 @@ jsxc.webrtc = {
       $.ajax(url, {
          async: true,
          xhrFields: {
-            withCredentials: true
+            withCredentials: jsxc.options.get('RTCPeerConfig').withCredentials
          },
          success: function(data) {
             var ttl = data.ttl || 3600;

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -133,6 +133,9 @@ jsxc.webrtc = {
 
       $.ajax(url, {
          async: true,
+         xhrFields: {
+            withCredentials: true
+         },
          success: function(data) {
             var ttl = data.ttl || 3600;
             var iceServers = data.iceServers;


### PR DESCRIPTION
To be able to work cross-domain, the destination domain need CORS to be
properly configured. withCredentials means that cookie are send then
performing the ajax call, allowing all kind of cookie based authentication.