### PR TITLE
Fix invalid parent selector

### DIFF
--- a/scss/_roster.scss
+++ b/scss/_roster.scss
@@ -233,7 +233,7 @@
     }
 }
 
-#jsxc_roster > {
+#jsxc_roster > & {
     &.jsxc_bottom {
         position: absolute;
         left: 0;


### PR DESCRIPTION
will throw an error if you use a libsass >= 3.3.2

Not sure if there is a better solution for this but the current will compile into:

`#jsxc_roster > .jsxc_bottom`

which is the intended one I guess