### PR TITLE
Stop each MediaStreamTrack individually

### DIFF
--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -620,7 +620,14 @@ jsxc.webrtc = {
       var bid = jsxc.jidToBid(session.peerID);
 
       if (this.localStream) {
-         this.localStream.stop();
+         if (typeof this.localStream.stop === 'function') {
+            this.localStream.stop();
+         } else {
+            var tracks = this.localStream.getTracks();
+            tracks.forEach(function(track) {
+               track.stop();
+            });
+         }
       }
 
       if ($('.jsxc_videoContainer').length) {


### PR DESCRIPTION
Method MediaStream.stop has been [deprecated](https://developers.google.com/web/updates/2015/07/mediastream-deprecations#stop-ended-and-active) since Google Chrome 45 in favor of stopping each track individually.