### PR TITLE
Fix auto-accept

### DIFF
--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -559,16 +559,7 @@ jsxc.webrtc = {
 
       jsxc.webrtc.last_caller = session.peerID;
 
-      if (jsxc.webrtc.AUTO_ACCEPT) {
-         self.reqUserMedia();
-         return;
-      }
-
-      var dialog = jsxc.gui.dialog.open(jsxc.gui.template.get('incomingCall', bid), {
-         noClose: true
-      });
-
-      dialog.find('.jsxc_accept').click(function() {
+      function acceptCall() {
          $(document).trigger('accept.call.jsxc');
 
          jsxc.switchEvents({
@@ -585,7 +576,18 @@ jsxc.webrtc = {
          });
 
          self.reqUserMedia();
+      }
+
+      if (jsxc.webrtc.AUTO_ACCEPT) {
+         acceptCall();
+         return;
+      }
+
+      var dialog = jsxc.gui.dialog.open(jsxc.gui.template.get('incomingCall', bid), {
+         noClose: true
       });
+
+      dialog.find('.jsxc_accept').click(acceptCall);
 
       dialog.find('.jsxc_reject').click(function() {
          jsxc.gui.dialog.close();


### PR DESCRIPTION
Here's bug: auto-accept does not start the video/audio stream, i.e. it opens call window, but no multimedia data is sent.