### PR TITLE
Bower dependencies are actually devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dev/
 /lib/emojione/
 lib/i18next/
 lib/jquery-i18next/
+/.idea

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "private": true,
-  "dependencies": {
+  "devdependencies": {
     "emojione": "~2.0.1",
     "favico.js": "^0.3.10",
     "strophe.bookmarks": "https://raw.githubusercontent.com/sualko/strophejs-plugins/bookmarks/bookmarks/strophe.bookmarks.js",

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "private": true,
-  "devdependencies": {
+  "devDependencies": {
     "emojione": "~2.0.1",
     "favico.js": "^0.3.10",
     "strophe.bookmarks": "https://raw.githubusercontent.com/sualko/strophejs-plugins/bookmarks/bookmarks/strophe.bookmarks.js",


### PR DESCRIPTION
Correct me if I'm wrong, but since all dependencies are also bundled in the build directory, there is no need for these to be marked as dependencies.

Marking them as devDependencies makes sure that these (rather huge) libraries are not included when including jsxc in other projects.