### PR TITLE
Clear userlist before appending entries from "getUsers" result.

### DIFF
--- a/src/jsxc.lib.gui.js
+++ b/src/jsxc.lib.gui.js
@@ -670,6 +670,7 @@ jsxc.gui = {
 
             if (val !== '') {
                jsxc.options.getUsers.call(this, val, function(list) {
+                  $('#jsxc_userlist').empty();
                   $.each(list || {}, function(uid, displayname) {
                      var option = $('<option>');
                      option.attr('data-username', uid);


### PR DESCRIPTION
If the server is returning entries slower than the user is entering
additional characters, the callback gets executed multiple times after,
the list has been cleared - resulting in the same entries being appended
multiple times.