### PR TITLE
[WIP] Add desktop sharing

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+scss:
+  config_file: .scss-lint.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 scss:
+  enabled: false
   config_file: .scss-lint.yml

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,56 @@
+scss_files: 'scss/*.scss'
+
+linters:
+  ColorKeyword:
+    enabled: false
+  ColorVariable:
+    enabled: false
+  Comment:
+    enabled: false
+  DuplicateProperty:
+    enabled: false
+  EmptyRule:
+    enabled: false
+  HexNotation:
+    enabled: false
+  IdSelector:
+    enabled: false
+  ImportPath:
+    enabled: false
+  ImportantRule:
+    enabled: false
+  Indentation:
+    enabled: false
+  LeadingZero:
+    enabled: false
+  MergeableSelector:
+    enabled: false
+  NameFormat:
+    enabled: false
+  NestingDepth:
+    enabled: false
+  PropertySortOrder:
+    enabled: false
+  PseudoElement:
+    enabled: false
+  QualifyingElement:
+    enabled: false
+  SelectorDepth:
+    enabled: false
+  SelectorFormat:
+    enabled: false
+  Shorthand:
+    enabled: false
+  SingleLinePerSelector:
+    enabled: false
+  StringQuotes:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: false
+  UnnecessaryParentReference:
+    enabled: false
+  UrlQuotes:
+    enabled: false
+  ZeroUnit:
+    enabled: false
+

--- a/img/bell.svg
+++ b/img/bell.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 39.041695 39.099998"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="bell.svg"
+   width="39.041695"
+   height="39.099998">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1879"
+     inkscape:window-height="1176"
+     id="namedview6"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="-11.174035"
+     inkscape:cy="19.6"
+     inkscape:window-x="1241"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 17.237829,2.3 0,1.3 c -9.8999997,1 -11.0999997,8.9 -12.0999997,15.9 -0.7,4.7 -1.3,9.6 -4.49999996,12.9 -0.6,0.7 -0.8,1.6 -0.5,2.5 0.4,0.8 1.19999996,1.4 2.09999996,1.4 l 14.2999997,0 c 0.1,1.6 1.3,2.8 2.9,2.8 1.5,0 2.8,-1.3 2.9,-2.8 l 14.4,0 c 0.9,0 1.8,-0.6 2.1,-1.4 0.4,-0.8 0.2,-1.8 -0.5,-2.5 -3.2,-3.3 -3.9,-8.2 -4.5,-12.9 -1,-7 -2.1,-14.9 -12,-15.9 l 0,-1.3 c 0,-1.3 -1,-2.3 -2.3,-2.3 -1.3,0 -2.3,1 -2.3,2.3 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#ffd42a"
+     sodipodi:nodetypes="sccccscscsccccsss" />
+</svg>

--- a/locales/el.json
+++ b/locales/el.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -261,7 +261,7 @@
     "No_local_audio_device": "No local audio device.",
     "No_local_video_device": "No local video device.",
     "Ok": "Ok",
-    "PermissionDeniedError": "You or your browser denied audio/video permission",
+    "PermissionDeniedError": "You or your browser denied media permission",
     "Use_local_audio_device": "Use local audio device.",
     "Use_local_video_device": "Use local video device.",
     "is_": "is __status__",
@@ -289,6 +289,15 @@
     "_is_composing": " is composing...",
     "_are_composing": " are composing...",
     "Chat_state_notifications": "Chat state notifications",
-    "setting-explanation-chat-state": "Do you want to send and receive chat state notifications, like someone starts or stops composing a message?"
+    "setting-explanation-chat-state": "Do you want to send and receive chat state notifications, like someone starts or stops composing a message?",
+    "Share_screen": "Share screen",
+    "Incoming_stream": "Incoming stream",
+    "Stream_started": "Stream started",
+    "HTTPS_REQUIRED": "This action requires an encrypted connection.",
+    "EXTENSION_UNAVAILABLE": "You need a browser extension/addon.",
+    "UNKNOWN_ERROR": "An unknown error occured.",
+    "Install_extension": "Please install the extension in order to use screen sharing: ",
+    "Connection_accepted": "Connection accepted",
+    "Stream_terminated": "Stream terminated"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "Con el Calco habilitado tu servidor XMPP enviará una copia de cada mensaje entrante dirigido a ti a este cliente incluso si no estaba siendo enviado a él",
     "setting-explanation-login": "Si esta opción está habilitada, el chat empezará al inicio de sesión",
     "setting-explanation-priority": "Si tú has iniciado sesión varias veces con la misma cuenta, tu servidor XMPP enviará los mensajes al cliente con la mayor prioridad",
-    "setting-explanation-xmpp": "Estas opciones son usadas para conectar con el servidor XMPP"
+    "setting-explanation-xmpp": "Estas opciones son usadas para conectar con el servidor XMPP",
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "Avec la copie carbone activé, votre serveur XMPP envera une copie de tous les messages entrant qui vous sont destiné à ce client, même s'il ne lui sont pas directement addressés.",
     "setting-explanation-login": "Si cette option est activé, le chat commencera lorsque vous vos connectez.",
     "setting-explanation-priority": "Si vous êtes connecté plusieurs fois avec le même compte, votre serveur XMPP enverra les messages au client ayant le plus haute priorité.",
-    "setting-explanation-xmpp": "Ces options sont utilisées pour se connecter au serveur XMPP."
+    "setting-explanation-xmpp": "Ces options sont utilisées pour se connecter au serveur XMPP.",
+    "_is_composing": " est en train d'écrire...",
+    "_are_composing": " sont en train d'écrire...",
+    "Chat_state_notifications": "Notifications de composition",
+    "setting-explanation-chat-state": "Voulez-vous envoyer et recevoir les notifications de composition, comme lorsque quelqu'un commence ou arrête d'écrire un message ?"
   }
 }

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/nds.json
+++ b/locales/nds.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": "Jeżeli ta opcja jest włączona, czat uruchomi się przy zalogowaniu.",
     "setting-explanation-priority": "Jeżeli jesteś zalogowany wiele razy na to samo konto twój serwer XMPP dostarczy wiadomości do klienta z najwyższym priorytetem.",
-    "setting-explanation-xmpp": "Te ustawienia używane są do połączenia z serwerem XMPP."
+    "setting-explanation-xmpp": "Te ustawienia używane są do połączenia z serwerem XMPP.",
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "Com carbon copy ativado seu servidor XMPP vai enviar uma copia de cada mensagem para você neste cliente mesmo que não tenha endereço",
     "setting-explanation-login": "Se essa opção esta habilitada, o chat vai começar ao logar.",
     "setting-explanation-priority": "Você esta logado varias vezes com a mesma conta, seu servidor XMPP vai entregar as mensagens para o cliente com a prioridade mais alta.",
-    "setting-explanation-xmpp": "Essas opções são usadas para conectar no Servidor XMPP"
+    "setting-explanation-xmpp": "Essas opções são usadas para conectar no Servidor XMPP",
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "С включенным Carbon Copy Ваш XMPP сервер будет отправлять копию каждого входящего сообщения на все подключенные устройства.",
     "setting-explanation-login": "Если эта опция включена, то чат будет начинаться сразу после аутентификации.",
     "setting-explanation-priority": "Если вы подключены к одному аккаунту с нескольких устройств, то XMPP сервер будет доставлять сообщения на клиент с наивысшим приоритетом.",
-    "setting-explanation-xmpp": "Эти настройки используются для подключения к XMPP серверу."
+    "setting-explanation-xmpp": "Эти настройки используются для подключения к XMPP серверу.",
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "Etkinleştirilmiş karbon kopya ile, XMPP sunucusu kendisine gönderilen her iletinin bir kopyasını, bu adrese gönderilmemiş olsa bile sizin için bu istemciye gönderir.",
     "setting-explanation-login": "Bu seçenek etkinleştirilirse, sohbet girişle beraber başlayacaktır.",
     "setting-explanation-priority": "Aynı hesapla bir çok kez oturum açtıysanız, XMPP sunucusu, istemciye  iletileri en yüksek öncelikle gönderecektir.",
-    "setting-explanation-xmpp": "Bu seçenekler XMPP sunucusuna bağlanmak için kullanılır."
+    "setting-explanation-xmpp": "Bu seçenekler XMPP sunucusuna bağlanmak için kullanılır.",
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": "如果打開副本選項的話，XMPP 伺服器會把每一個收到的訊息，都送一份到這個用戶端程式，即使它不是訊息發送的對象。",
     "setting-explanation-login": "打開這個選項會在登入時同時開啟聊天。",
     "setting-explanation-priority": "如果你用同一個帳號同時登入好幾次的話，XMPP 伺服器會把訊息送給優先度最高的那個用戶端程式。",
-    "setting-explanation-xmpp": "這些是用在 XMPP 伺服器連線的選項。"
+    "setting-explanation-xmpp": "這些是用在 XMPP 伺服器連線的選項。",
+    "_is_composing": "正在打字中...",
+    "_are_composing": "正在打字中...",
+    "Chat_state_notifications": "聊天狀態通知",
+    "setting-explanation-chat-state": "想要傳送以及接收聊天狀態的通知嗎？也就是有人開始或停止寫訊息之類？"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -285,6 +285,10 @@
     "setting-explanation-carbon": null,
     "setting-explanation-login": null,
     "setting-explanation-priority": null,
-    "setting-explanation-xmpp": null
+    "setting-explanation-xmpp": null,
+    "_is_composing": null,
+    "_are_composing": null,
+    "Chat_state_notifications": null,
+    "setting-explanation-chat-state": null
   }
 }

--- a/scss/_jsxc.scss
+++ b/scss/_jsxc.scss
@@ -356,17 +356,26 @@ img.jsxc_vCard {
     background-image: none;
     border: 1px solid transparent;
     border-radius: 4px;
+    transition: background-color 0.5s;
 
     &.jsxc_btn-default {
         border-color: #ccc;
         color: #555;
         background-color: rgba(240, 240, 240, 0.9);
+
+        &:hover {
+            background-color: #d6d6d6;
+        }
     }
 
     &.jsxc_btn-primary {
         color: #fff;
         background-color: #337ab7;
         border-color: #2e6da4;
+
+        &:hover {
+            background-color: #296496;
+        }
     }
 
     &[disabled], &[disabled]:hover {

--- a/scss/_webrtc.scss
+++ b/scss/_webrtc.scss
@@ -59,19 +59,61 @@
     }
 }
 
-$establishingColor1: #98d48f;
-$establishingColor2: #76ba6c;
+$establishingColor1: #a1a1a1;
+$establishingColor2: #f1f1f1;
 
 .jsxc_establishing:before {
+    content: '';
+    display: block;
+    width: 40px;
+    height: 10px;
+    box-sizing: border-box;
+    background-color: $establishingColor1;
+    animation-name: jsxc_establishing;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 20;
+    margin-left: -20px;
+    margin-top: -5px;
+}
+
+@keyframes jsxc_establishing {
+    0% {
+        border-width: 0px;
+        background-color: $establishingColor1;
+        width: 40px;
+        margin-left: -20px;
+    }
+
+    50% {
+        background-color: $establishingColor2;
+        width: 80px;
+        margin-left: -40px;
+    }
+
+    100% {
+        border-width: 0px;
+        background-color: $establishingColor1;
+        width: 40px;
+        margin-left: -20px;
+    }
+}
+
+$ringingColor1: #98d48f;
+$ringingColor2: #76ba6c;
+
+.jsxc_ringing:before {
     content: '';
     display: block;
     width: 20px;
     height: 20px;
     box-sizing: border-box;
-    border: 0px solid $establishingColor2;
-    background-color: $establishingColor1;
+    background-color: $ringingColor1;
     border-radius: 50%;
-    animation-name: jsxc_establishing;
+    animation-name: jsxc_ringing;
     animation-duration: 2s;
     animation-iteration-count: infinite;
     position: absolute;
@@ -82,11 +124,9 @@ $establishingColor2: #76ba6c;
     margin-top: -10px;
 }
 
-@keyframes jsxc_establishing {
+@keyframes jsxc_ringing {
     0% {
-        border-width: 0px;
-        border-color: $establishingColor2;
-        background-color: $establishingColor1;
+        background-color: $ringingColor1;
         width: 20px;
         height: 20px;
         margin-left: -10px;
@@ -94,8 +134,7 @@ $establishingColor2: #76ba6c;
     }
 
     50% {
-        border-color: $establishingColor1;
-        background-color: $establishingColor2;
+        background-color: $ringingColor2;
         width: 80px;
         height: 80px;
         margin-left: -40px;
@@ -103,9 +142,7 @@ $establishingColor2: #76ba6c;
     }
 
     100% {
-        border-width: 0px;
-        border-color: $establishingColor2;
-        background-color: $establishingColor1;
+        background-color: $ringingColor1;
         width: 20px;
         height: 20px;
         margin-left: -10px;
@@ -113,7 +150,7 @@ $establishingColor2: #76ba6c;
     }
 }
 
-.jsxc_ringing:before {
+.jsxc_bell:before {
     content: '';
     display: block;
     width: 80px;
@@ -134,7 +171,7 @@ $establishingColor2: #76ba6c;
     margin-top: -40px;
 }
 
-@keyframes jsxc_ringing {
+@keyframes jsxc_bell {
     0% {
         margin-left: -50px;
     }

--- a/scss/_webrtc.scss
+++ b/scss/_webrtc.scss
@@ -46,6 +46,128 @@
     }
 }
 
+.jsxc_establishing, .jsxc_ringing {
+    &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        background-color: rgba(0, 0, 0, 0.4);
+        z-index: 10;
+    }
+}
+
+$establishingColor1: #98d48f;
+$establishingColor2: #76ba6c;
+
+.jsxc_establishing:before {
+    content: '';
+    display: block;
+    width: 20px;
+    height: 20px;
+    box-sizing: border-box;
+    border: 0px solid $establishingColor2;
+    background-color: $establishingColor1;
+    border-radius: 50%;
+    animation-name: jsxc_establishing;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 20;
+    margin-left: -10px;
+    margin-top: -10px;
+}
+
+@keyframes jsxc_establishing {
+    0% {
+        border-width: 0px;
+        border-color: $establishingColor2;
+        background-color: $establishingColor1;
+        width: 20px;
+        height: 20px;
+        margin-left: -10px;
+        margin-top: -10px;
+    }
+
+    50% {
+        border-color: $establishingColor1;
+        background-color: $establishingColor2;
+        width: 80px;
+        height: 80px;
+        margin-left: -40px;
+        margin-top: -40px;
+    }
+
+    100% {
+        border-width: 0px;
+        border-color: $establishingColor2;
+        background-color: $establishingColor1;
+        width: 20px;
+        height: 20px;
+        margin-left: -10px;
+        margin-top: -10px;
+    }
+}
+
+.jsxc_ringing:before {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 80px;
+    box-sizing: border-box;
+    background-image: image-url("bell.svg");
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    animation-name: jsxc_ringing;
+    animation-duration: 1.5s;
+    animation-iteration-count: infinite;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 20;
+    margin-left: -40px;
+    margin-top: -40px;
+}
+
+@keyframes jsxc_ringing {
+    0% {
+        margin-left: -50px;
+    }
+
+    5% {
+        margin-left: -30px;
+    }
+
+    10% {
+        margin-left: -50px;
+    }
+
+    15% {
+        margin-left: -30px;
+    }
+
+    20% {
+        margin-left: -50px;
+    }
+
+    25% {
+        margin-left: -30px;
+    }
+
+    30% {
+        margin-left: -50px;
+    }
+
+    35% {
+        margin-left: -40px;
+    }
+}
+
 .jsxc_videoContainer {
     position: absolute;
     top: 0;
@@ -53,6 +175,22 @@
     right: 0px;
     bottom: 0px;
     background-color: $video_bg;
+
+    &.jsxc_minimized {
+        position: fixed;
+        top: 10px;
+        left: 10px;
+        right: auto;
+        bottom: auto;
+        z-index: 99;
+        background-color: transparent;
+        box-shadow: 0 0 10px #a1a1a1;
+
+        .jsxc_localvideo {
+            position: static;
+            display: block;
+        }
+    }
 
     video {
         display: none;
@@ -136,7 +274,7 @@
     bottom: 10px;
     z-index: 9990;
     background-color: $black;
-    cursor: pointer;
+    cursor: move;
 }
 
 div {
@@ -303,55 +441,6 @@ div {
         height: 100%;
         list-style: none;
         padding: 0;
-    }
-}
-
-.bubblingG {
-    text-align: center;
-    width: 129px;
-    height: 80px;
-    position: absolute;
-    top: 40%;
-    left: 50%;
-    margin-left: -64px;
-
-    span {
-        display: inline-block;
-        vertical-align: middle;
-        width: 16px;
-        height: 16px;
-        margin: 40px auto;
-        background: $bubbling_bg;
-        border-radius: 81px;
-        animation: bubblingG 1.3s infinite alternate;
-    }
-}
-
-#bubblingG_1 {
-    animation-delay: 0s;
-}
-
-#bubblingG_2 {
-    animation-delay: 0.39s;
-}
-
-#bubblingG_3 {
-    animation-delay: 0.78s;
-}
-
-@keyframes bubblingG {
-    0% {
-        width: 16px;
-        height: 16px;
-        background-color: $bubbling_start_bg;
-        transform: translateY(0);
-    }
-
-    100% {
-        width: 39px;
-        height: 39px;
-        background-color: $white;
-        transform: translateY(-34px);
     }
 }
 

--- a/scss/_window.scss
+++ b/scss/_window.scss
@@ -618,6 +618,15 @@
     box-sizing: border-box;
     margin-right: 3px;
     border-radius: 3px;
+    background-color: transparent;
+    font-size: 0.8em;
+    font-style: italic;
+
+    .jsxc_emoticon {
+        width: 1.2em;
+        height: 1.2em;
+        vertical-align: middle;
+    }
 
     &.jsxc_composing {
         text-align: center;

--- a/src/jsxc.lib.gui.js
+++ b/src/jsxc.lib.gui.js
@@ -2062,6 +2062,9 @@ jsxc.gui.window = {
       };
 
       win.find('.jsxc_more').click(expandClick);
+      win.find('.jsxc_menu').click(function() {
+         $('body').click();
+      });
 
       win.find('.jsxc_verification').click(function() {
          jsxc.gui.showVerification(bid);

--- a/src/jsxc.lib.options.js
+++ b/src/jsxc.lib.options.js
@@ -301,7 +301,7 @@ jsxc.options = {
     * @see example extensions {@link https://github.com/otalk/getScreenMedia}
     */
    screenMediaExtension: {
-     firefox: '',
-     chrome: ''
+      firefox: '',
+      chrome: ''
    }
 };

--- a/src/jsxc.lib.options.js
+++ b/src/jsxc.lib.options.js
@@ -292,5 +292,16 @@ jsxc.options = {
    /** Default option for chat state notifications */
    chatState: {
       enable: true
+   },
+
+   /**
+    * Download urls to screen media extensions.
+    *
+    * @type {Object}
+    * @see example extensions {@link https://github.com/otalk/getScreenMedia}
+    */
+   screenMediaExtension: {
+     firefox: '',
+     chrome: ''
    }
 };

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -701,13 +701,15 @@ jsxc.webrtc = {
       var bid = jsxc.jidToBid(session.peerID);
 
       if (this.localStream) {
-         if (typeof this.localStream.stop === 'function') {
-            this.localStream.stop();
-         } else {
+         if (typeof this.localStream.getTracks === 'function') {
             var tracks = this.localStream.getTracks();
             tracks.forEach(function(track) {
                track.stop();
             });
+         } else if (typeof this.localStream.stop === 'function') {
+            this.localStream.stop();
+         } else {
+            jsxc.warn('Could not stop local stream');
          }
       }
 

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -729,7 +729,10 @@ jsxc.webrtc = {
       self.remoteStream = null;
 
       jsxc.gui.closeVideoWindow();
-      //@TODO stop ringing + close dialog
+
+      // Close incoming call dialog and stop ringing
+      jsxc.gui.dialog.close();
+      $(document).trigger('reject.call.jsxc');
 
       $(document).off('error.jingle');
 

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -870,6 +870,7 @@ jsxc.webrtc = {
             });
 
             var session = self.conn.jingle.initiate(jid);
+            session.call = true;
 
             session.on('change:connectionState', $.proxy(self.onIceConnectionStateChanged, self));
 
@@ -954,6 +955,7 @@ jsxc.webrtc = {
             }
 
             var session = self.conn.jingle.initiate(jid, undefined, constraints);
+            session.call = false;
 
             session.on('change:connectionState', $.proxy(self.onIceConnectionStateChanged, self));
             session.on('accepted', function() {

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -247,13 +247,16 @@ jsxc.webrtc = {
       var div = $('<div>').addClass('jsxc_video');
       win.find('.jsxc_tools .jsxc_settings').after(div);
 
-      // @TODO check if download url is available
-      // Add screen sharing button
-      var a = $('<a>');
-      a.text($.t('Share_screen'));
-      a.addClass('jsxc_shareScreen jsxc_video');
-      a.attr('href', '#');
-      win.find('.jsxc_settings .jsxc_menu li:last').after($('<li>').append(a));
+      var screenMediaExtension = jsxc.options.get('screenMediaExtension') || {};
+      var browser = self.conn.jingle.RTC.webrtcDetectedBrowser;
+      if (screenMediaExtension[browser] || jsxc.storage.getItem('debug')) {
+         // Add screen sharing button if extension is available or we are in debug mode
+         var a = $('<a>');
+         a.text($.t('Share_screen'));
+         a.addClass('jsxc_shareScreen jsxc_video');
+         a.attr('href', '#');
+         win.find('.jsxc_settings .jsxc_menu li:last').after($('<li>').append(a));
+      }
 
       self.updateIcon(win.data('bid'));
    },

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -954,14 +954,15 @@ jsxc.webrtc = {
 
             var browser = self.conn.jingle.RTC.webrtcDetectedBrowser;
 
-            if (jsxc.options.screenMediaExtension && jsxc.options.screenMediaExtension[browser] &&
+            var screenMediaExtension = jsxc.options.get('screenMediaExtension') || {};
+            if (screenMediaExtension[browser] &&
                (err.name === 'EXTENSION_UNAVAILABLE' || (err.name === 'NotAllowedError' && browser === 'firefox'))) {
                // post download link after explanation
                setTimeout(function() {
                   jsxc.gui.window.postMessage({
                      bid: jsxc.jidToBid(jid),
                      direction: jsxc.Message.SYS,
-                     msg: $.t('Install_extension') + jsxc.options.screenMediaExtension[browser]
+                     msg: $.t('Install_extension') + screenMediaExtension[browser]
                   });
                }, 500);
             }

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -952,15 +952,15 @@ jsxc.webrtc = {
             var browser = self.conn.jingle.RTC.webrtcDetectedBrowser;
 
             if (jsxc.options.screenMediaExtension && jsxc.options.screenMediaExtension[browser] &&
-              (err.name === 'EXTENSION_UNAVAILABLE' || (err.name === 'NotAllowedError' && browser === 'firefox'))) {
-                // post download link after explanation
-              setTimeout(function() {
+               (err.name === 'EXTENSION_UNAVAILABLE' || (err.name === 'NotAllowedError' && browser === 'firefox'))) {
+               // post download link after explanation
+               setTimeout(function() {
                   jsxc.gui.window.postMessage({
                      bid: jsxc.jidToBid(jid),
                      direction: jsxc.Message.SYS,
                      msg: $.t('Install_extension') + jsxc.options.screenMediaExtension[browser]
                   });
-              }, 500);
+               }, 500);
             }
          }
       });

--- a/src/jsxc.lib.webrtc.js
+++ b/src/jsxc.lib.webrtc.js
@@ -911,13 +911,13 @@ jsxc.webrtc = {
       self.last_caller = jid;
 
       // @TODO generalize
-      $(document).on('mediaready.jingle', function(ev, stream){
-        jsxc.webrtc.localStream = stream;
-        jsxc.webrtc.conn.jingle.localStream = stream;
+      $(document).on('mediaready.jingle', function(ev, stream) {
+         jsxc.webrtc.localStream = stream;
+         jsxc.webrtc.conn.jingle.localStream = stream;
 
-        jsxc.gui.showMinimizedVideoWindow();
+         jsxc.gui.showMinimizedVideoWindow();
 
-        $(document).trigger('finish.mediaready.jsxc');
+         $(document).trigger('finish.mediaready.jsxc');
       });
 
       jsxc.switchEvents({
@@ -1235,35 +1235,35 @@ jsxc.webrtc = {
 };
 
 jsxc.gui.showMinimizedVideoWindow = function() {
-  var self = jsxc.webrtc;
+   var self = jsxc.webrtc;
 
-  // needed to trigger complete.dialog.jsxc
-  jsxc.gui.dialog.close();
+   // needed to trigger complete.dialog.jsxc
+   jsxc.gui.dialog.close();
 
-  var videoContainer = $('<div/>');
-  videoContainer.addClass('jsxc_videoContainer jsxc_minimized');
-  videoContainer.appendTo('body');
-  videoContainer.draggable({
-     containment: "parent"
-  });
+   var videoContainer = $('<div/>');
+   videoContainer.addClass('jsxc_videoContainer jsxc_minimized');
+   videoContainer.appendTo('body');
+   videoContainer.draggable({
+      containment: "parent"
+   });
 
-  var videoElement = $('<video class="jsxc_localvideo" autoplay=""></video>');
-  videoElement.appendTo(videoContainer);
+   var videoElement = $('<video class="jsxc_localvideo" autoplay=""></video>');
+   videoElement.appendTo(videoContainer);
 
-  videoElement[0].muted = true;
-  videoElement[0].volume = 0;
+   videoElement[0].muted = true;
+   videoElement[0].volume = 0;
 
-  if (self.localStream) {
-     self.attachMediaStream(videoElement, self.localStream);
-  }
+   if (self.localStream) {
+      self.attachMediaStream(videoElement, self.localStream);
+   }
 
-  videoContainer.append('<div class="jsxc_controlbar jsxc_visible"><div><div class="jsxc_hangUp jsxc_videoControl"></div></div></div></div>');
-  videoContainer.find('.jsxc_hangUp').click(function() {
-     jsxc.webrtc.hangUp('success');
-  });
-  videoContainer.click(function() {
-     videoContainer.find('.jsxc_controlbar').toggleClass('jsxc_visible');
-  });
+   videoContainer.append('<div class="jsxc_controlbar jsxc_visible"><div><div class="jsxc_hangUp jsxc_videoControl"></div></div></div></div>');
+   videoContainer.find('.jsxc_hangUp').click(function() {
+      jsxc.webrtc.hangUp('success');
+   });
+   videoContainer.click(function() {
+      videoContainer.find('.jsxc_controlbar').toggleClass('jsxc_visible');
+   });
 };
 
 /**
@@ -1359,9 +1359,9 @@ jsxc.gui.closeVideoWindow = function() {
    var win = $('#jsxc_webrtc .jsxc_chatarea > ul > li');
 
    if (win.length > 0) {
-     $('#jsxc_windowList > ul').prepend(win.detach());
-     win.find('.slimScrollDiv').resizable('enable');
-     jsxc.gui.window.resize(win);
+      $('#jsxc_windowList > ul').prepend(win.detach());
+      win.find('.slimScrollDiv').resizable('enable');
+      jsxc.gui.window.resize(win);
    }
 
    $('#jsxc_webrtc, .jsxc_videoContainer').remove();

--- a/template/confirmDialog.html
+++ b/template/confirmDialog.html
@@ -1,4 +1,4 @@
 <p data-var="msg"></p>
 
-<button class="btn btn-primary jsxc_confirm pull-right" data-i18n="Confirm"></button>
-<button class="btn btn-default jsxc_dismiss jsxc_close pull-right" data-i18n="Dismiss"></button>
+<button class="jsxc_btn jsxc_btn-primary jsxc_confirm pull-right" data-i18n="Confirm"></button>
+<button class="jsxc_btn jsxc_btn-default jsxc_dismiss jsxc_close pull-right" data-i18n="Dismiss"></button>

--- a/template/incomingCall.html
+++ b/template/incomingCall.html
@@ -3,5 +3,5 @@
    <span data-i18n="Do_you_want_to_accept_the_call_from"></span> <span data-var="bid_name" />?
 </p>
 
-<button class="btn btn-primary jsxc_accept pull-right" data-i18n="Accept"></button>
-<button class="btn btn-default jsxc_reject pull-right" data-i18n="Reject"></button>
+<button class="jsxc_btn jsxc_btn-primary jsxc_accept pull-right" data-i18n="Accept"></button>
+<button class="jsxc_btn jsxc_btn-default jsxc_reject pull-right" data-i18n="Reject"></button>

--- a/template/videoWindow.html
+++ b/template/videoWindow.html
@@ -6,9 +6,6 @@
       <video class="jsxc_localvideo" autoplay></video>
       <video class="jsxc_remotevideo" autoplay></video>
       <div class="jsxc_status"></div>
-      <div class="bubblingG">
-         <span id="bubblingG_1"> </span> <span id="bubblingG_2"> </span> <span id="bubblingG_3"> </span>
-      </div>
       <div class="jsxc_noRemoteVideo">
          <div>
             <div></div>


### PR DESCRIPTION
fix #8

There are some browser limitations for desktop sharing:

- support only in chrome and firefox with custom extension
  - every domain which requests screen media, needs his own extension
  - example extension can be found at https://github.com/otalk/getScreenMedia
- requires https

**TODO**
- [x] remove all todos in `jsxc.lib.webrtc.js`
- [x] modify ui on sender side
- [x] test ff
- [x] create wiki page
- [x] add option for link to extension download

![screenshot from 2017-01-12 16-45-06](https://cloud.githubusercontent.com/assets/2974196/21896541/092e7514-d8e7-11e6-8490-997ca8516905.png)
![screenshot from 2017-01-12 16-45-27](https://cloud.githubusercontent.com/assets/2974196/21896549/0e9a4d34-d8e7-11e6-8463-5939406c59d1.png)