### PR TITLE
Update strophe.disco.js

### DIFF
--- a/lib/strophe.disco.js
+++ b/lib/strophe.disco.js
@@ -127,7 +127,7 @@ Strophe.addConnectionPlugin('disco',
 
         var info = $iq({from:this._connection.jid,
                          to:jid, type:'get'}).c('query', attrs);
-        this._connection.sendIQ(info, success, error, timeout);
+        return this._connection.sendIQ(info, success, error, timeout);
     },
     /** Function: items
      * Items query


### PR DESCRIPTION
The id from sendIQ should be returned from the info request to pair with the response.
Reference: https://github.com/jsxc/jsxc/issues/591