### PR TITLE
Send Condition on connfail so custom handlers can check it

### DIFF
--- a/src/jsxc.lib.xmpp.js
+++ b/src/jsxc.lib.xmpp.js
@@ -130,7 +130,7 @@ jsxc.xmpp = {
                $(document).trigger('disconnected.jsxc');
                break;
             case Strophe.Status.CONNFAIL:
-               $(document).trigger('connfail.jsxc');
+               $(document).trigger('connfail.jsxc', condition);
                break;
             case Strophe.Status.AUTHFAIL:
                $(document).trigger('authfail.jsxc');


### PR DESCRIPTION
Before this commit https://github.com/jsxc/jsxc/commit/487e32a7b9a676e7527e96fccc9d7d748c02437a#diff-4e5734936042c4309a95a260fd764feaL3328 the condition would be send. Currently the `jsxc.xmpp.onConnfail` tries to uses this condition, but instead logs `undefined`.

This would be very useful for https://github.com/nextcloud/jsxc.nextcloud/pull/57