### PR TITLE
Prevent undefined 'last' key in array loop when marking quotations

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -269,6 +269,11 @@ export default class Message implements Identifiable, IMessage {
       let inQuote = false;
 
       for (let lineNumber in lines) {
+         if (!lines.hasOwnProperty(lineNumber)) {
+            //This value comes from Array prototype
+            continue;
+         }
+
          let line = lines[lineNumber];
 
          if (line.indexOf('&gt;') === 0) {


### PR DESCRIPTION
When marking quotations, we loop into the typed lines.

In some configurations, the for loop set the lineNumber to 'last' at the end, so the line can't be retrieved and an undefined error is triggered in the "line.indexOf' part.