### PR TITLE
Fix the rendering of messages of the current user when a room window is just opened

### DIFF
--- a/src/jsxc.lib.gui.js
+++ b/src/jsxc.lib.gui.js
@@ -2659,7 +2659,7 @@ jsxc.gui.window = {
          });
       }
 
-      if (message.direction === 'in' && !jsxc.gui.window.get(message.bid).find('.jsxc_textinput').is(":focus")) {
+      if (message.direction === jsxc.Message.IN && !jsxc.gui.window.get(message.bid).find('.jsxc_textinput').is(":focus")) {
          jsxc.gui.unreadMsg(message.bid);
 
          $(document).trigger('postmessagein.jsxc', [message.bid, message.htmlMsg]);
@@ -2669,9 +2669,9 @@ jsxc.gui.window = {
          jsxc.xmpp.sendMessage(message);
       }
 
-      jsxc.gui.window._postMessage(message);
+      jsxc.gui.window.renderMessage(message);
 
-      if (message.direction === 'out' && message.msg === '?' && jsxc.options.get('theAnswerToAnything') !== false) {
+      if (message.direction === jsxc.Message.OUT && message.msg === '?' && jsxc.options.get('theAnswerToAnything') !== false) {
          if (typeof jsxc.options.get('theAnswerToAnything') === 'undefined' || (Math.random() * 100 % 42) < 1) {
             jsxc.options.set('theAnswerToAnything', true);
 
@@ -2693,7 +2693,7 @@ jsxc.gui.window = {
     * @param {Object} post Post object with direction, msg, uid, received
     * @param {Bool} restore If true no highlights are used
     */
-   _postMessage: function(message, restore) {
+   renderMessage: function(message, restore) {
       var bid = message.bid;
       var win = jsxc.gui.window.get(bid);
       var msg = message.msg;
@@ -2953,7 +2953,7 @@ jsxc.gui.window = {
             var message = new jsxc.Message(c);
             message.save();
 
-            jsxc.gui.window._postMessage(message, true);
+            jsxc.gui.window.renderMessage(message, true);
          }
 
          jsxc.storage.removeUserItem('chat', bid);
@@ -2964,7 +2964,7 @@ jsxc.gui.window = {
       while (history !== null && history.length > 0) {
          var uid = history.pop();
 
-         jsxc.gui.window._postMessage(new jsxc.Message(uid), true);
+         jsxc.gui.window.renderMessage(new jsxc.Message(uid), true);
       }
    },
 

--- a/src/jsxc.lib.muc.js
+++ b/src/jsxc.lib.muc.js
@@ -1391,14 +1391,31 @@ jsxc.muc = {
             body = null;
          }
 
-         jsxc.gui.window.postMessage({
-            bid: room,
-            direction: jsxc.Message.IN,
-            msg: body,
-            stamp: stamp,
-            sender: sender,
-            attachment: attachment
-         });
+         if (id && $(message).find('delay').length > 0) {
+            // we are in a groupchat messages restoring
+            var direction = jsxc.Message.IN;
+            if (sender.jid && jsxc.jidToBid(sender.jid) === jsxc.bid) {
+               direction = jsxc.Message.OUT;
+            }
+            jsxc.gui.window.renderMessage(new jsxc.Message({
+               bid: room,
+               direction: direction,
+               msg: body,
+               stamp: stamp,
+               sender: sender,
+               attachment: attachment
+            }));
+         } else {
+            // we receive an incoming message
+            jsxc.gui.window.postMessage({
+               bid: room,
+               direction: jsxc.Message.IN,
+               msg: body,
+               stamp: stamp,
+               sender: sender,
+               attachment: attachment
+            });
+         }
       }
 
       var subject = $(message).find('subject');

--- a/src/jsxc.lib.storage.js
+++ b/src/jsxc.lib.storage.js
@@ -430,7 +430,7 @@ jsxc.storage = {
                   jsxc.xmpp.sendMessage(message);
                }
 
-               jsxc.gui.window._postMessage(message, true);
+               jsxc.gui.window.renderMessage(message, true);
             } else if (message.isReceived()) {
                el.addClass('jsxc_received');
             }


### PR DESCRIPTION
onGroupChatMessage is invoked when a room window is opened by jsxc. Each message passed as argument to this function seams to come from
the XMPP service (ejabberd in my case) and among them there is the
messages from the current user. The change in the function is to take
care of the messages coming from the current user: in this case, the
direction is explicitly set to jsxc.Message.OUT and the message is
then simply rendered.

Replace some explicit value 'in' or 'out' for message direction by
their respective constant jsxc.Message.IN and jsxc.Message.OUT.
Rename the function jsxc.gui.window._postMessage by
jsxc.gui.window.renderMessage.