### PR TITLE
fix: fullscreen view on call, prevent adding second video tag on

### DIFF
--- a/src/ui/VideoDialog.ts
+++ b/src/ui/VideoDialog.ts
@@ -118,12 +118,7 @@ export class VideoDialog {
 
       if ($.support.fullscreen) {
          this.dom.find('.jsxc-fullscreen').click(() => {
-            $(document).one('disabled.fullscreen', function() {
-               // Reset position of localvideo
-               localVideoElement.removeAttr('style');
-            });
-
-            // (<any>$('#jsxc_webrtc .jsxc_videoContainer')).fullscreen();
+            (<any> this.dom).fullscreen();
          });
       } else {
          this.dom.find('.jsxc-fullscreen').hide();

--- a/src/ui/VideoWindow.ts
+++ b/src/ui/VideoWindow.ts
@@ -73,8 +73,12 @@ export default class VideoWindow {
       this.videoDialog.setStatus(isVideoDevice ? 'Use remote video device.' : 'No remote video device');
       this.videoDialog.setStatus(isAudioDevice ? 'Use remote audio device.' : 'No remote audio device');
 
-      this.videoElement = $('<video autoplay></video>');
-      this.videoElement.appendTo(this.wrapperElement);
+      this.videoElement = this.wrapperElement.find('video');
+
+      if (this.videoElement.length === 0) {
+         this.videoElement = $('<video autoplay></video>');
+         this.videoElement.appendTo(this.wrapperElement);
+      }
 
       VideoDialog.attachMediaStream(this.videoElement, stream);
 


### PR DESCRIPTION
Enter fullscreen mode on call and preventing adding second video tag into jsxc-video-wrapper.
If enter fullscreen and then exit `jsxc-video-wrapper` contains 2 elements `'<video autoplay></video>'`

from debug logs. Please note that this log entries was captured before clicking on 'fullscreen' button and after. At least for its not clear why this is happening so providing an workaround (not good solution but at least something).
```plain
Log.ts:101 [Debug] [JINGLE][log:info] c869f632-1c8a-4266-8c82-e594e23d71f9: Stream removed
Log.ts:101 [Debug] Remote stream for c869f632-1c8a-4266-8c82-e594e23d71f9 removed.
Log.ts:101 [Debug] [JINGLE][log:info] c869f632-1c8a-4266-8c82-e594e23d71f9: Changing connection state to: disconnected
Log.ts:101 [Debug] connection state for c869f632-1c8a-4266-8c82-e594e23d71f9 disconnected
Log.ts:101 [Debug] [JINGLE][log:info] c869f632-1c8a-4266-8c82-e594e23d71f9: Changing session state to: ended
Log.ts:101 [Debug] Session c869f632-1c8a-4266-8c82-e594e23d71f9 was removed. Reason: Вызов завершен: сбросили.
Log.ts:101 [Debug] [Webrtc] Initiate call
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Changing session state to: pending
8Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Discovered new ICE candidate
Log.ts:101 [Debug] [JINGLE][log:debug] 2a16c162-4fe9-417c-81a5-590ae95665d0: session-info
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Outgoing session is ringing
Log.ts:101 [Debug] [Webrtc] ringing...
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Changing connection state to: connecting
Log.ts:101 [Debug] connection state for 2a16c162-4fe9-417c-81a5-590ae95665d0 connecting
Log.ts:101 [Debug] [JINGLE][log:debug] 2a16c162-4fe9-417c-81a5-590ae95665d0: session-accept
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Changing session state to: active
2Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Track added
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Changing connection state to: connected
Log.ts:101 [Debug] connection state for 2a16c162-4fe9-417c-81a5-590ae95665d0 connected
Log.ts:101 [Debug] Remote stream for session 2a16c162-4fe9-417c-81a5-590ae95665d0 added.
Log.ts:101 [Debug] [Webrtc] Use remote video device.
Log.ts:101 [Debug] [Webrtc] Use remote audio device.
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: Stream added
Log.ts:101 [Debug] Remote stream for session 2a16c162-4fe9-417c-81a5-590ae95665d0 added.
Log.ts:101 [Debug] [Webrtc] Use remote video device.
Log.ts:101 [Debug] [Webrtc] Use remote audio device.
Log.ts:101 [Debug] [JINGLE][log:info] 2a16c162-4fe9-417c-81a5-590ae95665d0: ICE end of candidates
2Log.ts:101 [Debug] [JINGLE][log:debug] 2a16c162-4fe9-417c-81a5-590ae95665d0: transport-info
```
