### PR TITLE
fix: handle empty stream

### DIFF
--- a/src/ui/VideoDialog.ts
+++ b/src/ui/VideoDialog.ts
@@ -259,6 +259,12 @@ export class VideoDialog {
    }
 
    private static stopStream(stream) {
+
+      if (!stream) {
+         Log.warn('Could not stop stream. Stream is null.');
+         return;
+      }
+
       if (typeof stream.getTracks === 'function') {
          let tracks = stream.getTracks();
          tracks.forEach(function(track) {


### PR DESCRIPTION
When user starts video call in Jitsi Meet application at JSXC appears Incoming call notification.
User accepts it but if he wants to hang up(drop) call he wont be able to do it because argument stream is null and in console will be message which looks like 
``` can not get property getTracks from ...``` 