### PR TITLE
PluginApi enhastments (plugin options)

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -3,7 +3,7 @@ import Storage from './Storage'
 import { NoticeManager } from './NoticeManager'
 import PluginRepository from './plugin/PluginRepository'
 import Log from './util/Log'
-import Options from './Options'
+import Options, {IOptionData} from './Options'
 import PresenceController from './PresenceController'
 import PageVisibility from './PageVisibility'
 import ChatWindowList from './ui/ChatWindowList';
@@ -54,9 +54,12 @@ export default class Client {
       return '4.0.0';
    }
 
-   public static addPlugin(Plugin: IPlugin) {
+   public static addPlugin(Plugin: IPlugin, defaultOptions?: IOptionData) {
       try {
          PluginRepository.add(Plugin);
+         if (defaultOptions) {
+            Options.addDefaults(defaultOptions);
+         }
       } catch (err) {
          Log.warn('Error while adding Plugin: ' + err);
       }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -58,7 +58,9 @@ export default class Client {
       try {
          PluginRepository.add(Plugin);
          if (defaultOptions) {
-            Options.addDefaults(defaultOptions);
+            let options = {};
+            options[Plugin.getName()] = defaultOptions;
+            Options.addDefaults(options);
          }
       } catch (err) {
          Log.warn('Error while adding Plugin: ' + err);

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -8,7 +8,7 @@ import Client from './Client';
 
 const KEY = 'options';
 
-interface IOptionData {
+export interface IOptionData {
    [key: string]: any
 }
 

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -6,6 +6,7 @@ import FormWatcher, { SettingsCallback } from '../../FormWatcher'
 import { disconnect } from './disconnect';
 import Translation from '@util/Translation';
 import loginBox from '@ui/dialogs/loginBox';
+import {IOptionData} from '@src/Options';
 
 export { disconnect };
 export { start, startAndPause } from './start'
@@ -13,8 +14,8 @@ export { register } from './register'
 export { enableDebugMode, disableDebugMode, deleteAllData } from './debug'
 export { testBOSHServer } from './testBOSHServer'
 
-export function addPlugin(Plugin: IPlugin) {
-   Client.addPlugin(Plugin);
+export function addPlugin(Plugin: IPlugin, defaultOptions?: IOptionData) {
+   Client.addPlugin(Plugin, defaultOptions);
 }
 
 export function addMenuEntry(options: { id: string, handler: (ev) => void, label: string | JQuery<HTMLElement>, icon?: string, offlineAvailable?: boolean }) {

--- a/src/plugin/PluginAPI.interface.ts
+++ b/src/plugin/PluginAPI.interface.ts
@@ -37,6 +37,8 @@ export interface IPluginAPI {
 
    getVersion(): string
 
+   getOption(key: string)
+
    addPreSendMessageProcessor(processor: (contact: Contact, message: IMessage) => Promise<{}>, position?: number)
 
    addAfterReceiveMessageProcessor(processor: (contact: Contact, message: IMessage, stanza: Element) => Promise<{}>, position?: number)

--- a/src/plugin/PluginAPI.ts
+++ b/src/plugin/PluginAPI.ts
@@ -88,6 +88,10 @@ export default class PluginAPI implements IPluginAPI {
       return Client.getVersion();
    }
 
+   public getOption(key: string) {
+      return this.account.getOption(key);
+   }
+
    public addPreSendMessageProcessor(processor: (contact: Contact, message: Message) => Promise<{}>, position?: number) {
       this.account.getPipe('preSendMessage').addProcessor(processor, position);
    }


### PR DESCRIPTION
Once again faced with limited Plugin functionality for developers. 
So this pull request allows Plugin to get settings via getOption method call and gives ability to set custom options for plugin.

 simple example usage
```javascript
let JSXC_MIN_VERSION = '4.0.0';
let JSXC_MAX_VERSION = '4.9999.0';

class GroupMeetingCall extends JSXC.AbstractPlugin {

   options;

   constructor(pluginAPI) {
      super(JSXC_MIN_VERSION, JSXC_MAX_VERSION, pluginAPI);

      this.options = {
         ...GroupMeetingCall.defaultOptions(),
         ...(pluginAPI.getOption(GroupMeetingCall.getName()) || {})
      };
      const invalidUrl = !this.getMeetUrl();
      pluginAPI.registerChatWindowInitializedHook((chatWindow) => {
         if (chatWindow.getContact().getType() !== 'groupchat' || invalidUrl) {
            return;
         }
         chatWindow.addMenuEntry('meet', 'Call', () => this.startCall(chatWindow));
      });
   }

   getMeetUrl() {
      return this.options.url;
   }

   static getName() {
      return 'GroupMeetingCall';
   }

   static defaultOptions() {
      return {
         'url': ''
      }
   }

   startCall(chatWindow) {
      let jid = chatWindow.getContact().getJid().node;
      let url = this.getMeetUrl();

      if (!url.endsWith('/')) {
         url += '/';
      }

      let a = document.createElement('a');
      a.href = url + jid;
      a.target = '_blank';
      a.rel = 'noopener noreferrer';
      a.click();
   }
}

// set options.
jsxc.addPlugin(GroupMeetingCall, {
    'url': 'https://meet.jitsi.si/'
});

// use default plugin options
// jsxc.addPlugin(GroupMeetingCall)
```