### PR TITLE
fix: display name of muc rooms is not taken into account

### DIFF
--- a/src/MultiUserContact.ts
+++ b/src/MultiUserContact.ts
@@ -44,7 +44,7 @@ export default class MultiUserContact extends Contact {
    constructor(account: Account, jid: IJID, name?: string);
    constructor(account: Account, id: string);
    constructor() {
-      super(arguments[0], arguments[1], arguments[3]);
+      super(arguments[0], arguments[1], arguments[2]);
 
       this.data.set('type', MultiUserContact.TYPE);
    }


### PR DESCRIPTION
The wrong argument is passed to the super class Contact in the constructor of the MUC class so the display name is not taken into account