### PR TITLE
feat: password sub element in bookmark storage for conference element

### DIFF
--- a/src/MultiUserContact.ts
+++ b/src/MultiUserContact.ts
@@ -179,6 +179,10 @@ export default class MultiUserContact extends Contact {
       return this.data.get('subject');
    }
 
+   public getPassword(): string {
+      return this.data.get('password');
+   }
+
    public setPassword(password: string) {
       this.data.set('password', password);
    }

--- a/src/plugins/bookmarks/BookmarkProvider.ts
+++ b/src/plugins/bookmarks/BookmarkProvider.ts
@@ -54,8 +54,9 @@ export default class BookmarkProvider extends ContactProvider {
       let alias = contact.hasName() ? contact.getName() : undefined;
       let nickname = contact.getNickname();
       let autoJoin = contact.isAutoJoin();
+      let password = contact.getPassword();
 
-      return new RoomBookmark(id, alias, nickname, autoJoin);
+      return new RoomBookmark(id, alias, nickname, autoJoin, password);
    }
 
    public createContact(jid: IJID, name?: string): MultiUserContact;
@@ -135,6 +136,7 @@ export default class BookmarkProvider extends ContactProvider {
    private initBookmarkContact(bookmark: RoomBookmark, service: AbstractService): IContact {
       let contact = this.createContact(bookmark.getJid());
       contact.setNickname(bookmark.getNickname());
+      contact.setPassword(bookmark.getPassword());
       contact.setBookmark(true);
       contact.setAutoJoin(bookmark.isAutoJoin());
       contact.setProvider(this);

--- a/src/plugins/bookmarks/RoomBookmark.ts
+++ b/src/plugins/bookmarks/RoomBookmark.ts
@@ -1,7 +1,7 @@
 import { IJID } from '@src/JID.interface';
 
 export default class RoomBookmark {
-   constructor(private id: IJID, private alias?: string, private nickname?: string, private autoJoin: boolean = false) {
+   constructor(private id: IJID, private alias?: string, private nickname?: string, private autoJoin: boolean = false, private password?: string) {
 
    }
 
@@ -27,6 +27,14 @@ export default class RoomBookmark {
 
    public getNickname(): string {
       return this.nickname;
+   }
+
+   public hasPassword(): boolean {
+      return !!this.password;
+   }
+
+   public getPassword(): string {
+      return this.password;
    }
 
    public isAutoJoin(): boolean {

--- a/src/plugins/bookmarks/services/LocalService.ts
+++ b/src/plugins/bookmarks/services/LocalService.ts
@@ -20,7 +20,7 @@ export default class LocalService extends AbstractService {
       for (let id in data) {
          let roomData = data[id];
 
-         rooms.push(new RoomBookmark(new JID(id), roomData.alias, roomData.nickname, roomData.autoJoin));
+         rooms.push(new RoomBookmark(new JID(id), roomData.alias, roomData.nickname, roomData.autoJoin, roomData.password));
       }
 
       return rooms;
@@ -34,6 +34,7 @@ export default class LocalService extends AbstractService {
          alias: room.getAlias(),
          nickname: room.getNickname(),
          autoJoin: room.isAutoJoin(),
+         password: room.getPassword(),
       };
 
       this.storage.setItem('rooms', data);

--- a/src/plugins/bookmarks/services/PubSubService.ts
+++ b/src/plugins/bookmarks/services/PubSubService.ts
@@ -53,9 +53,11 @@ export class PubSubService extends AbstractService {
       let alias = element.getAttribute('name');
       let nickElement = element.getElementsByTagName('nick');
       let nickname = nickElement.length === 1 ? nickElement[0].textContent : undefined;
+      let passwordElement = element.getElementsByTagName('password');
+      let password = passwordElement.length === 1 ? passwordElement[0].textContent : undefined;
       let autoJoin = element.getAttribute('autojoin') === 'true';
 
-      return new RoomBookmark(jid, alias, nickname, autoJoin);
+      return new RoomBookmark(jid, alias, nickname, autoJoin, password);
    }
 
    // private createBookmarksNode() {
@@ -100,6 +102,12 @@ export class PubSubService extends AbstractService {
          let nickElement = $('<nick>');
          nickElement.text(room.getNickname());
          nickElement.appendTo(conferenceElement);
+      }
+
+      if (room.hasPassword()) {
+         let passwordElement = $('<password>');
+         passwordElement.text(room.getPassword());
+         passwordElement.appendTo(conferenceElement);
       }
 
       storageElement.append(conferenceElement);


### PR DESCRIPTION
Ref : https://xmpp.org/extensions/attic/xep-0048-1.0.html part 2.2

The "password" sub-element should be stored when it's present in the contact data (refer to https://github.com/jsxc/jsxc/pull/807)