### PR TITLE
fix:  use getId() for checking set encryption state

### DIFF
--- a/src/Contact.ts
+++ b/src/Contact.ts
@@ -269,7 +269,6 @@ export default class Contact implements IIdentifiable, IContact {
       if (state !== EncryptionState.Plaintext && !source) {
          throw new Error('No encryption source provided');
       }
-
       this.data.set('encryptionPlugin', state === EncryptionState.Plaintext ? null : source);
       this.data.set('encryptionState', state);
    }

--- a/src/plugins/omemo/Plugin.ts
+++ b/src/plugins/omemo/Plugin.ts
@@ -63,8 +63,8 @@ export default class OMEMOPlugin extends EncryptionPlugin {
          return;
       }
 
-      if (contact.getEncryptionPluginName() === OMEMOPlugin.getName()) {
-         contact.setEncryptionState(EncryptionState.Plaintext, OMEMOPlugin.getName());
+      if (contact.getEncryptionPluginName() === OMEMOPlugin.getId()) {
+         contact.setEncryptionState(EncryptionState.Plaintext, OMEMOPlugin.getId());
          return;
       }
 
@@ -77,7 +77,7 @@ export default class OMEMOPlugin extends EncryptionPlugin {
             throw new Error(Translation.t('There_are_new_OMEMO_devices'));
          }
 
-         contact.setEncryptionState(EncryptionState.UnverifiedEncrypted, OMEMOPlugin.getName());
+         contact.setEncryptionState(EncryptionState.UnverifiedEncrypted, OMEMOPlugin.getId());
       });
    }
 
@@ -140,7 +140,7 @@ export default class OMEMOPlugin extends EncryptionPlugin {
          return Promise.resolve([message, xmlElement]);
       }
 
-      if (contact.getEncryptionPluginName() !== OMEMOPlugin.getName()) {
+      if (contact.getEncryptionPluginName() !== OMEMOPlugin.getId()) {
          return Promise.resolve([message, xmlElement]);
       }
 

--- a/src/plugins/otr/Plugin.ts
+++ b/src/plugins/otr/Plugin.ts
@@ -104,7 +104,7 @@ export default class OTRPlugin extends EncryptionPlugin {
    }
 
    private updateMenuEntry(contact: IContact, menuEntry: JQuery) {
-      if (contact.isEncrypted() && contact.getEncryptionPluginName() === OTRPlugin.getName()) {
+      if (contact.isEncrypted() && contact.getEncryptionPluginName() === OTRPlugin.getId()) {
          menuEntry.removeClass('jsxc-disabled');
       } else {
          menuEntry.addClass('jsxc-disabled');
@@ -125,7 +125,7 @@ export default class OTRPlugin extends EncryptionPlugin {
    }
 
    private preSendMessageProcessor = (contact: Contact, message: Message): Promise<[Contact, Message]> => {
-      if (contact.getEncryptionState() === EncryptionState.Plaintext || contact.getEncryptionPluginName() !== OTRPlugin.getName()) {
+      if (contact.getEncryptionState() === EncryptionState.Plaintext || contact.getEncryptionPluginName() !== OTRPlugin.getId()) {
          return Promise.resolve([contact, message]);
       }
 

--- a/src/plugins/otr/Session.ts
+++ b/src/plugins/otr/Session.ts
@@ -188,9 +188,9 @@ export default class Session {
       this.saveSession();
 
       if (verified) {
-         this.peer.setEncryptionState(EncryptionState.VerifiedEncrypted, OTRPlugin.getName());
+         this.peer.setEncryptionState(EncryptionState.VerifiedEncrypted, OTRPlugin.getId());
       } else {
-         this.peer.setEncryptionState(EncryptionState.UnverifiedEncrypted, OTRPlugin.getName());
+         this.peer.setEncryptionState(EncryptionState.UnverifiedEncrypted, OTRPlugin.getId());
       }
    }
 
@@ -212,7 +212,7 @@ export default class Session {
 
             this.inform(msgState + '_private_conversation_started');
 
-            this.peer.setEncryptionState(this.session.trust ? EncryptionState.VerifiedEncrypted : EncryptionState.UnverifiedEncrypted, 'otr');
+            this.peer.setEncryptionState(this.session.trust ? EncryptionState.VerifiedEncrypted : EncryptionState.UnverifiedEncrypted, OTRPlugin.getId());
             break;
          case OTR.CONST.STATUS_END_OTR:
             if (this.session.msgstate === OTR.CONST.MSGSTATE_PLAINTEXT) {
@@ -220,13 +220,13 @@ export default class Session {
 
                this.inform('private_conversation_aborted');
 
-               this.peer.setEncryptionState(EncryptionState.Plaintext, 'otr');
+               this.peer.setEncryptionState(EncryptionState.Plaintext, OTRPlugin.getId());
             } else {
                // the buddy abort the private conversation
 
                this.inform('your_buddy_closed_the_private_conversation_you_should_do_the_same');
 
-               this.peer.setEncryptionState(EncryptionState.Ended, 'otr');
+               this.peer.setEncryptionState(EncryptionState.Ended, OTRPlugin.getId());
             }
             break;
          case OTR.CONST.STATUS_SMP_HANDLE:


### PR DESCRIPTION
When trying to turn on / off some encryption plugin you will get in console 
```plain
Uncaught Error: Couldn't find omemo
    at PluginRepository.getEncryptionPlugin (PluginRepository.ts:81)
    at HTMLDivElement.eval (ChatWindow.ts:474)
    at HTMLDivElement.dispatch (jquery.min.js:2)
    at HTMLDivElement.y.handle (jquery.min.js:2)
```

OMEMO was not working - well messages was not encrypted and was send as plain text. 

since ```PluginRepository.getEncryptionPlugin ``` moved to method ```getID()``` so changed rest parts . 