### PR TITLE
fix: ignore components which does not support DiscoInfo on determining MUC services at XMPP server

### DIFF
--- a/src/ui/dialogs/multiUserJoin.ts
+++ b/src/ui/dialogs/multiUserJoin.ts
@@ -116,14 +116,10 @@ class MultiUserJoinDialog {
             }).then((hasFeature) => {
                return hasFeature ? jid : undefined;
             }).catch((stanza) => {
-            const from = $(stanza).attr('from') || '';
-            if ($(stanza).find('service-unavailable').length > 0) {
-               Log.warn(`Service unavailable for ${from}`, stanza);
-            } else {
-               Log.error(`Could not load get DiscoInfo for ${from}`, stanza);
-               throw stanza;
-            }
-         });
+               const from = $(stanza).attr('from') || '';
+            
+               Log.info(`Ignore ${from} as MUC provider, because could not load disco info.`);
+            });
 
             promises.push(promise);
          });

--- a/src/ui/dialogs/multiUserJoin.ts
+++ b/src/ui/dialogs/multiUserJoin.ts
@@ -115,7 +115,15 @@ class MultiUserJoinDialog {
                return discoInfoRepository.hasFeature(discoInfo, 'http://jabber.org/protocol/muc');
             }).then((hasFeature) => {
                return hasFeature ? jid : undefined;
-            });
+            }).catch((stanza) => {
+            const from = $(stanza).attr('from') || '';
+            if ($(stanza).find('service-unavailable').length > 0) {
+               Log.warn(`Service unavailable for ${from}`, stanza);
+            } else {
+               Log.error(`Could not load get DiscoInfo for ${from}`, stanza);
+               throw stanza;
+            }
+         });
 
             promises.push(promise);
          });


### PR DESCRIPTION
Jitsi has speakerstats_component which is not support getting discoinfo and responses with 
```xml
<iq xmlns="jabber:client" type="error" to="as@site.com/jsxc-6e71fee0" from="speakerstats.site.com" id="4bcd4257-0c2a-423a-b458-60b3d9079b8d:sendIQ">
<error type="cancel">
    <service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
</error>
</iq>
```
which is stopping searching for MUC component domain.

Following change set allows to ignore ``service-unavailable`` for components which does not support disco items request and will re-throw ``stanza`` item in something else happend. 