### PR TITLE
feat: adding support for RTL messages in chat

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -262,7 +262,7 @@ export default class Message implements IIdentifiable, IMessage {
       body = Utils.escapeHTML(body);
       body = await Message.formatText(body, this.getDirection(), this.getPeer());
 
-      return `<p>${body}</p>`;
+      return `<p dir="auto">${body}</p>`;
    }
 
    public getPlaintextEmoticonMessage(): string {
@@ -344,7 +344,7 @@ function markQuotation(text: string) {
 }
 
 function replaceLineBreaks(text: string) {
-   return text.replace(/(\r\n|\r|\n)/g, '<br />');
+   return text.replace(/(\r\n|\r|\n)/g, '</p><p dir="auto">');
 }
 
 Message.addFormatter(convertUrlToLink);

--- a/template/chatWindow.hbs
+++ b/template/chatWindow.hbs
@@ -33,7 +33,7 @@
              {{> menu
                     classes="jsxc-menu--emoticons jsxc-shrink--no jsxc-menu--dark jsxc-menu--drop-bottom-left"
                     button-classes="jsxc-icon jsxc-icon--emoticon jsxc-icon--clickable"}}
-            <textarea class="jsxc-message-input" placeholder="{{t "Message"}}"></textarea>
+            <textarea class="jsxc-message-input" placeholder="{{t "Message"}}" dir="auto"></textarea>
             <div class="jsxc-file-transfer" title="{{t "Send_file"}}">
                <label><input type="file" name="files" /><label>
             </div>


### PR DESCRIPTION
- A simple addition to the textarea markup (`dir="auto"`) to allow the modern browser to automatically decide the direction of the text (LTR/RTL).

- Addition of same markup (`dir="auto"`) to the `<p>` tag of chat messages.

- Change of line-break code: instead of `<br />`, the lines are split with `<p>` tags so the direction markup can be applied per line. This allows the different lines of the same message to have a different direction (e.g., when writing one line of English and one of Hebrew/Arabic/etc).


MDN info about `dir="auto"`:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir 