### PR TITLE
feat: Added image paste feature (resolves #856)

### DIFF
--- a/src/ui/ChatWindowFileTransferHandler.ts
+++ b/src/ui/ChatWindowFileTransferHandler.ts
@@ -3,10 +3,11 @@ import Attachment from '../Attachment'
 
 export default class FileTransferHandler {
    private handlerElement;
-   private inputElement;
+   private inputElement: JQuery<HTMLElement>;
 
    constructor(private chatWindow: ChatWindow) {
       this.handlerElement = this.chatWindow.getDom().find('.jsxc-file-transfer');
+      this.inputElement = this.chatWindow.getDom().find('.jsxc-message-input');
 
       this.handlerElement.on('click', this.showFileSelection);
 

--- a/src/ui/ChatWindowFileTransferHandler.ts
+++ b/src/ui/ChatWindowFileTransferHandler.ts
@@ -3,11 +3,14 @@ import Attachment from '../Attachment'
 
 export default class FileTransferHandler {
    private handlerElement;
+   private inputElement;
 
    constructor(private chatWindow: ChatWindow) {
       this.handlerElement = this.chatWindow.getDom().find('.jsxc-file-transfer');
 
       this.handlerElement.on('click', this.showFileSelection);
+
+      this.inputElement.on('paste', this.pasteImageAsFile);
 
       this.chatWindow.getDom().find('.jsxc-window').on('drop', (ev) => {
          ev.preventDefault();
@@ -51,4 +54,18 @@ export default class FileTransferHandler {
       let attachment = new Attachment(file);
       this.chatWindow.setAttachment(attachment);
    }
+
+   private pasteImageAsFile = (ev: any) => {
+      // this handles older browsers
+      let items = (ev.clipboardData  || ev.originalEvent.clipboardData).items;
+      for (let i in items) {
+         // poormans check if opbject is an image
+         if (items[i].type !== undefined && items[i].type.indexOf('image') === 0) {
+            const blob = items[i].getAsFile();
+            // load pasted blob as file if present
+            this.fileSelected(blob);
+            break;
+         }
+      }
+  };
 }


### PR DESCRIPTION
JSXC is great! I'd like to help JSXC stay awesome :) 

This merge hopefully resolves #856 via a paste event trigger from the chatWindow input. This event triggers a check if the clipboard contains an image. If so the clipboard is read in as a blob and processed using the existing methods for file uploading.

