### PR TITLE
Fix duplicate message when load mam

### DIFF
--- a/src/plugins/mam/Archive.ts
+++ b/src/plugins/mam/Archive.ts
@@ -73,7 +73,12 @@ export default class Archive {
 
       if (!firstResultId) {
          let lastMessage = this.contact.getTranscript().getLastMessage();
-         endDate = lastMessage ? lastMessage.getStamp() : undefined;
+         if (lastMessage) {
+            endDate = lastMessage.getStamp();
+            endDate.setSeconds(endDate.getSeconds() - 1);
+         } else {
+            endDate = undefined;
+         }
       }
 
       let connection = this.plugin.getConnection();


### PR DESCRIPTION
Issue is:
* User A and user B chat with each other, and a lot of messages archived to server
* User A use a new PC or web browser, or clear browser storage
* User B send user A message like "Hello"
* User A received message from user B "Hello", and click "Load history message"
* User A now received message "Hello" twice

Solve:
When get archived message, the query param "endDate" can be earlier than last message by 1 second, and wont miss any message.