### PR TITLE
improve muc join dialog

### DIFF
--- a/src/ui/dialogs/multiUserJoin.ts
+++ b/src/ui/dialogs/multiUserJoin.ts
@@ -67,6 +67,12 @@ class MultiUserJoinDialog {
       this.getMultiUserServices().then((services: JID[]) => {
          this.serverInputElement.val(services[0].full);
          this.serverInputElement.trigger('change');
+
+         $('#jsxc-serverlist select').empty();
+
+         services.forEach(service => {
+            $('#jsxc-serverlist select').append($('<option>').text(service.domain));
+         })
       });
    }
 
@@ -138,7 +144,23 @@ class MultiUserJoinDialog {
          });
 
          return Promise.all(promises).then((results) => {
-            return results.filter(jid => typeof jid !== 'undefined');
+            return results
+               .filter(jid => typeof jid !== 'undefined')
+               .sort(function compare(a, b) {
+                  if (!a.domain || !b.domain) {
+                     return 0;
+                  }
+
+                  if (a.domain.startsWith('conference') && !b.domain.startsWith('conference')) {
+                     return -1;
+                  }
+
+                  if (!a.domain.startsWith('conference') && b.domain.startsWith('conference')) {
+                     return +1;
+                  }
+
+                  return a.domain.localeCompare(b.domain);
+               });
          });
       })
    }
@@ -224,7 +246,7 @@ class MultiUserJoinDialog {
 
    private testInputValues(): Promise<JID | void> {
       let room = <string> this.roomInputElement.val();
-      let server = this.serverInputElement.val();
+      let server = this.serverInputElement.val()?this.serverInputElement.val():this.serverInputElement.attr('placeholder');
 
       if (!room || !room.match(/^[^"&\'\/:<>@\s]+$/i)) {
          this.roomInputElement.addClass('jsxc-invalid').keyup(function() {

--- a/template/multiUserJoin.hbs
+++ b/template/multiUserJoin.hbs
@@ -12,10 +12,19 @@
    <div class="form-group">
       <label class="col-sm-4 control-label" for="jsxc-server">{{t "Server"}}</label>
       <div class="col-sm-8">
-         <input type="text" name="server" id="jsxc-server" class="form-control" required="required" pattern="^[.-0-9a-zA-Z]+" />
+         <input type="text" name="server" id="jsxc-server" class="form-control" required="required" pattern="^[.-0-9a-zA-Z]+" list="jsxc-serverlist" />
          <p class="jsxc-inputinfo jsxc-server jsxc-hidden"></p>
       </div>
    </div>
+   <datalist id="jsxc-serverlist">
+      <p>
+         <label for="jsxc-serverlist-selection"></label>
+         <select id="jsxc-serverlist-selection">
+            <option></option>
+            <option>workaround</option>
+         </select>
+      </p>
+   </datalist>
    <div class="form-group">
       <label class="col-sm-4 control-label" for="jsxc-room">{{t "Room"}}</label>
       <div class="col-sm-8">


### PR DESCRIPTION
Englisch:
-ensure that if multiple muc services are given, that "conference" (which is normaly the default muc service)  is shown in input field
-furthermore sort the muc services by name
-add a list to server input which includes all muc services (double click if empty)

Deutsch:
-Stellt sicher, dass beim Vorhandensein mehrerer MUC Dienste, der "conference"-Dienst angezeigt wird.
("conference" ist normalerweise der Standard-Dienst für MUC).
-Sind weitere MUC-Dienste vorhanden werden diese an Hand der Domain alphabetisch sortiert.
-Die Liste der MUC-Dienste wird nach Doppelklick auf das leere Inputfeld angezeigt.