### PR TITLE
increase windowsize - width from 250 to 320

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -13,7 +13,7 @@
 //fonts
 $font-sans: Arial, sans-serif;
 
-$default-window-width: 250px;
+$default-window-width: 320px;
 
 @import "partials/avatar";
 @import "partials/button";


### PR DESCRIPTION
Because the lock icon was not visible with 250px width, 320px is fine now