### PR TITLE
fix scrollbar in chatarea going outside

### DIFF
--- a/scss/partials/_bar.scss
+++ b/scss/partials/_bar.scss
@@ -6,7 +6,7 @@
   height: 44px;
   padding: 0 3px;
   position: relative;
-  width: 100%;
+  width: 100% !important;
 
   &__action-entry {
     cursor: pointer;

--- a/scss/partials/_window.scss
+++ b/scss/partials/_window.scss
@@ -49,7 +49,7 @@
     flex-grow: 1;
     left: 0;
     overflow: auto;
-    padding: 3px;
+    padding: 3px 0 3px 0;
     width: 100%;
     z-index: 10;
   }


### PR DESCRIPTION
on some browsers the chatwindow scrollbar was not completly inside the chatbox

u see the scrollbar which is not completly inside and plz notice that the jsxc-bar on top has not the same size as the chatarea (there is a little white line on the right)


Firefox:

![firefox2](https://user-images.githubusercontent.com/24775073/103448954-0f980a00-4ca1-11eb-93fe-9129beee230c.PNG)
![firefox1](https://user-images.githubusercontent.com/24775073/103448955-1030a080-4ca1-11eb-8899-b51c1ee36764.PNG)

Chrome:

![chrome1](https://user-images.githubusercontent.com/24775073/103448958-17f04500-4ca1-11eb-936a-1d0599cc19aa.PNG)

