### PR TITLE
add Tags to Roster Item

### DIFF
--- a/scss/partials/_bar.scss
+++ b/scss/partials/_bar.scss
@@ -89,17 +89,25 @@
   }
 
   &--has-unread-msg {
-    .jsxc-bar__caption__secondary::before {
-      background-color: $unread-bg;
-      border-radius: 50%;
-      color: $unread-color;
-      content: "";
-      display: inline-block;
-      height: 0.8em;
-      line-height: 100%;
-      margin-right: 0.2em;
-      text-align: center;
-      width: 0.8em;
+    .jsxc-bar__caption {
+      font-weight: bold;
+    }
+
+    .jsxc-bar__caption__secondary {
+      font-style: italic;
+
+      &::before {
+        background-color: $unread-bg;
+        border-radius: 50%;
+        color: $unread-color;
+        content: "";
+        display: inline-block;
+        height: 0.8em;
+        line-height: 100%;
+        margin-right: 0.2em;
+        text-align: center;
+        width: 0.8em;
+      }
     }
   }
 

--- a/scss/partials/_bar.scss
+++ b/scss/partials/_bar.scss
@@ -57,6 +57,37 @@
     }
   }
 
+  &__tags {
+    float: left;
+    line-height: 0;
+    padding-top: 2px;
+  }
+
+  &__tag {
+    background-color: #bbb;
+    border: 0;
+    color: var(--jsxc-color-primary-text);
+    display: inline-block;
+    font-size: 8px;
+    height: 12px;
+    line-height: 12px;
+    margin-right: 1px;
+    max-width: 12px;
+    overflow: hidden;
+    padding: 0 0.5em;
+    text-indent: 999px;
+    text-overflow: clip;
+    transition: max-width 0.5s;
+    white-space: nowrap;
+    width: 12px;
+
+    &:hover {
+      max-width: 999px;
+      text-indent: unset;
+      width: auto;
+    }
+  }
+
   &--has-unread-msg {
     .jsxc-bar__caption__secondary::before {
       background-color: $unread-bg;

--- a/scss/partials/_jsxc.scss
+++ b/scss/partials/_jsxc.scss
@@ -206,3 +206,13 @@ ul.jsxc-vcard {
   overflow: auto;
   width: 500px;
 }
+
+.jsxc-tag {
+  border-radius: 0.7em;
+  color: var(--jsxc-color-primary-text);
+  font-size: 0.8em;
+  height: 1.4em;
+  line-height: 1.4em;
+  margin-right: 0.25em;
+  padding: 0.2em 0.5em;
+}

--- a/src/ui/Roster.ts
+++ b/src/ui/Roster.ts
@@ -274,6 +274,10 @@ export default class Roster {
       mainMenu.prepend(li);
    }
 
+   public setFilter(filter: string = '') {
+      this.element.find('.jsxc-filter-input').val(filter).trigger('keyup');
+   }
+
    private insert(rosterItem: RosterItem) {
       let contact = rosterItem.getContact();
       let list = contact.isChat() ? this.contactList : this.groupList;
@@ -489,15 +493,16 @@ export default class Roster {
             return;
          }
 
-         listElements.not(`[data-jid*="${filterValue}"]`).not(`[data-name*="${filterValue}"]`).addClass('jsxc-roster-item--filtered');
+         listElements.not(`[data-jid*="${filterValue}"]`).not(`[data-name*="${filterValue}"]`).not(`[data-groups*="${filterValue}"]`).addClass('jsxc-roster-item--filtered');
          listElements.filter(`[data-jid*="${filterValue}"]`).removeClass('jsxc-roster-item--filtered');
          listElements.filter(`[data-name*="${filterValue}"]`).removeClass('jsxc-roster-item--filtered');
+         listElements.filter(`[data-groups*="${filterValue}"]`).removeClass('jsxc-roster-item--filtered');
       });
 
       this.element.find('.jsxc-filter-wrapper .jsxc-clear').on('mousedown', (ev) => {
          ev.preventDefault();
 
-         this.element.find('.jsxc-filter-input').val('').trigger('keyup');
+         this.setFilter('');
       });
 
       this.element.find('.jsxc-collapsible').on('click', function () {

--- a/src/ui/RosterItem.ts
+++ b/src/ui/RosterItem.ts
@@ -9,6 +9,7 @@ import Translation from '../util/Translation'
 import Client from '@src/Client';
 import Log from '@util/Log'
 import Color from '../util/Color'
+import Roster from '@ui/Roster'
 
 let rosterItemTemplate = require('../../template/roster-item.hbs')
 
@@ -31,8 +32,9 @@ export default class RosterItem {
       this.element.attr('data-presence', Presence[this.contact.getPresence()]);
       this.element.attr('data-subscription', this.contact.getSubscription());
       this.element.attr('data-date', this.contact.getLastMessageDate()?.toISOString());
+      this.element.attr('data-groups', this.contact.getGroups().join(',').toLowerCase());
 
-     this.appendTags();
+      this.appendTags();
 
       this.element.on('dragstart', (ev) => {
          (<any> ev.originalEvent).dataTransfer.setData('text/plain', contact.getJid().full);
@@ -151,11 +153,16 @@ export default class RosterItem {
    private appendTags() {
       let groups = this.contact.getGroups();
       let tagElements = groups.map(group => {
-         let element = $('<span>');
+         let element = $('<button>');
 
          element.text(group);
          element.addClass('jsxc-bar__tag');
          element.css('background-color', Color.generate(group));
+         element.on('click', ev => {
+            ev.preventDefault();
+
+            Roster.get().setFilter(group);
+         })
 
          return element;
       });

--- a/src/ui/RosterItem.ts
+++ b/src/ui/RosterItem.ts
@@ -8,6 +8,7 @@ import { IContact } from '../Contact.interface'
 import Translation from '../util/Translation'
 import Client from '@src/Client';
 import Log from '@util/Log'
+import Color from '../util/Color'
 
 let rosterItemTemplate = require('../../template/roster-item.hbs')
 
@@ -30,6 +31,8 @@ export default class RosterItem {
       this.element.attr('data-presence', Presence[this.contact.getPresence()]);
       this.element.attr('data-subscription', this.contact.getSubscription());
       this.element.attr('data-date', this.contact.getLastMessageDate()?.toISOString());
+
+     this.appendTags();
 
       this.element.on('dragstart', (ev) => {
          (<any> ev.originalEvent).dataTransfer.setData('text/plain', contact.getJid().full);
@@ -143,6 +146,21 @@ export default class RosterItem {
 
       this.contact.getTranscript().registerHook('unreadMessageIds', updateUnreadMessage);
       updateUnreadMessage();
+   }
+
+   private appendTags() {
+      let groups = this.contact.getGroups();
+      let tagElements = groups.map(group => {
+         let element = $('<span>');
+
+         element.text(group);
+         element.addClass('jsxc-bar__tag');
+         element.css('background-color', Color.generate(group));
+
+         return element;
+      });
+
+      this.element.find('.jsxc-bar__tags').empty().append(tagElements);
    }
 
    public getDom() {

--- a/src/ui/dialogs/vcard.ts
+++ b/src/ui/dialogs/vcard.ts
@@ -2,6 +2,7 @@ import Dialog from '../Dialog'
 import { IContact } from '../../Contact.interface'
 import Translation from '@util/Translation';
 import { Presence } from '@connection/AbstractConnection';
+import Color from '@util/Color';
 
 let vcardTemplate = require('../../../template/vcard.hbs');
 let vcardBodyTemplate = require('../../../template/vcard-body.hbs');
@@ -29,6 +30,19 @@ export default function(contact: IContact) {
 
    dialog = new Dialog(content);
    dialog.open();
+
+   let groups = contact.getGroups();
+   dialog.getDom().find('.jsxc-vcard-tags').append(
+      groups.map(group => {
+         let element = $('<span>');
+
+         element.text(group);
+         element.addClass('jsxc-tag');
+         element.css('background-color', Color.generate(group));
+
+         return element;
+      })
+   );
 
    for (let resource of resources) {
       let clientElement = dialog.getDom().find(`[data-resource="${resource}"] .jsxc-client`);

--- a/template/roster-item.hbs
+++ b/template/roster-item.hbs
@@ -3,6 +3,7 @@
 
    <div class="jsxc-bar__caption jsxc-grow">
       <div title="{{jid}}" class="jsxc-bar__caption__primary">{{name}}</div>
+      <div title="{{tag}}" class="jsxc-bar__tags"></div>
       <div title="{{lastMessage}}" class="jsxc-bar__caption__secondary">{{lastMessage}}</div>
    </div>
 

--- a/template/vcard.hbs
+++ b/template/vcard.hbs
@@ -1,4 +1,6 @@
 <h3>{{t "Info_about"}} {{name}} ({{jid}})</h3>
+<div class="jsxc-vcard-tags"></div>
+
 <ul class="jsxc-vcard">
    {{#each basic}}
    <li>


### PR DESCRIPTION

![tag1](https://user-images.githubusercontent.com/24775073/103489214-15adf800-4e13-11eb-9e53-a87d26c0ff51.PNG)
![tag2](https://user-images.githubusercontent.com/24775073/103489215-15adf800-4e13-11eb-93a4-1270f0d76896.PNG)



Options:
- showTags: true = force Tag-text, false = circle with hover to show text
- blinkNewMessages: true = blinking avatar on new messages, false = no blinking

fix #77

this shows the roster groups as labels unter de statustext/lastmessages fields
multiple groups are joined in one line ... 
if there is to less place the string will be ellipsized and could be read by a mouseover action