### PR TITLE
fix: fix input padding

### DIFF
--- a/scss/partials/_window.scss
+++ b/scss/partials/_window.scss
@@ -260,7 +260,7 @@
   margin: 0;
   min-height: auto;
   outline: none;
-  padding: 10px 5px 5px 0;
+  padding: 0;
   resize: none;
   transition: height 0.2s;
 


### PR DESCRIPTION
![4](https://user-images.githubusercontent.com/24775073/103725509-08da0180-4fd7-11eb-9bb8-12c8bea83933.PNG)
latest css fixes for chatwindow results in to much padding in input
so that the characters became nearly invisible (as you can see in the picture)