### PR TITLE
fix: use getAllRegisteredPlugins instead of getAllEnabledRegisteredPl…

### DIFF
--- a/src/plugin/PluginRepository.ts
+++ b/src/plugin/PluginRepository.ts
@@ -39,7 +39,7 @@ export default class PluginRepository {
    constructor(private account: Account) {
       let accountDisabledPlugins = account.getOption('disabledPlugins');
 
-      this.getAllEnabledRegisteredPlugins().forEach((Plugin) => {
+      this.getAllRegisteredPlugins().forEach((Plugin) => {
          if (accountDisabledPlugins.indexOf(Plugin.getId()) > -1) {
             Log.debug(`${Plugin.getId()} was disabled by the user.`);
 


### PR DESCRIPTION
if using getAllEnabledRegisteredPlugins instead of getAllRegisteredPlugins  the default disabled plugins could never be enabled in settings.
So now with getAllRegisteredPlugins  we are able to enable the default disabled plugins too.