### PR TITLE
fix: check for allready existing muc in roster

### DIFF
--- a/src/ui/Roster.ts
+++ b/src/ui/Roster.ts
@@ -301,7 +301,9 @@ export default class Roster {
          if ((lastMessageDate && pointerDate && lastMessageDate > pointerDate) ||
             (lastMessageDate && !pointerDate) ||
             (!lastMessageDate && !pointerDate && contactName.localeCompare(pointerName) === -1)) {
-
+            if (list.find('.jsxc-roster-item[data-id="' + contact.getId() + '"]').length > 0) {
+              list.find('.jsxc-roster-item[data-id="' + contact.getId() + '"]').detach();
+            }
             pointer.before(rosterItem.getDom().detach());
 
             return;
@@ -309,7 +311,9 @@ export default class Roster {
 
          pointer = pointer.next();
       }
-
+      if (list.find('.jsxc-roster-item[data-id="' + contact.getId() + '"]').length > 0) {
+          list.find('.jsxc-roster-item[data-id="' + contact.getId() + '"]').detach();
+      }
       rosterItem.getDom().appendTo(list);
    }
 


### PR DESCRIPTION
- this code inserts an additional check if the item is allready in the list to prevent double inserts

fix #1009