### PR TITLE
fix: message presend process not working

### DIFF
--- a/src/ui/ChatWindow.ts
+++ b/src/ui/ChatWindow.ts
@@ -463,13 +463,12 @@ export default class ChatWindow {
          unread: false,
       });
 
-      this.getTranscript().pushMessage(message);
-
       this.clearAttachment();
 
       let pipe = this.getAccount().getPipe('preSendMessage');
 
       pipe.run(this.contact, message).then(([contact, message]) => {
+         this.getTranscript().pushMessage(message);
          this.getAccount().getConnection().sendMessage(message);
       }).catch(err => {
          Log.warn('Error during preSendMessage pipe', err);


### PR DESCRIPTION
Problem is

* When I process a message in presend functions, like do some string replacement on message content.
* Send the message out, sender's message area shows a new message without those string replacement .
* But the receiver got a new message which is processed and string replaced.

This PR can fix this problem