### PR TITLE
style: dont hide groups when using "only show online contacts"

### DIFF
--- a/scss/partials/_roster.scss
+++ b/scss/partials/_roster.scss
@@ -247,7 +247,7 @@ input.jsxc-filter-input {
   }
 
   &.jsxc-hide-offline {
-    .jsxc-roster-item[data-presence="offline"] {
+    .jsxc-roster-item[data-presence="offline"]:not(.jsxc-roster-item[data-type="groupchat"]) {
       display: none;
     }
 

--- a/template/roster.hbs
+++ b/template/roster.hbs
@@ -10,7 +10,6 @@
 
       <button class="jsxc-collapsible jsxc-active">{{t "groups"}}</button>
       <ul class="jsxc-group-list" data-empty-list-label="{{t "Your_group_list_is_empty"}}"
-         data-offline-hidden-label="{{t "Offline_contacts_are_hidden"}}"
          data-presence-offline-label="{{t "You_are_currently_offline"}}"></ul>
 
       <button class="jsxc-collapsible jsxc-active">{{t "contacts"}}</button>


### PR DESCRIPTION
If enabled the "only show online contacts" it should not hide the groups in the roster too.
I changed the css to not hide data-type=groupchat and removed the offline label in the li-element.
I think if someone dont want to see the groups, they could be collapsed.