### PR TITLE
fix: sync conversations after login

### DIFF
--- a/src/ContactManager.ts
+++ b/src/ContactManager.ts
@@ -91,6 +91,10 @@ export default class ContactManager {
       storage.setItem('contacts', 'loaded', true);
    }
 
+   public getContacts(): { [key: string]: IContact } {
+      return this.contacts;
+   }
+
    public async add(contact: IContact): Promise<void> {
       this.contacts[contact.getId()] = contact;
 

--- a/src/Transcript.ts
+++ b/src/Transcript.ts
@@ -23,6 +23,65 @@ export default class Transcript {
       });
    }
 
+   public insertMessage(message: IMessage)
+   {
+
+      if (!this.messages||this.messages[message.getUid()])
+      {
+         return;
+      }
+
+      let indexMessageArray = [];
+
+      for (let strId in this.messages)
+      {
+         indexMessageArray.push(this.messages[strId]);
+      }
+
+      indexMessageArray.sort(function compare(a:IMessage, b:IMessage) {
+         if (a.getStamp().getTime() === b.getStamp().getTime()) {
+            return 0;
+         }
+
+         if (a.getStamp().getTime() < b.getStamp().getTime()) {
+            return -1;
+         }
+
+         if (a.getStamp().getTime() > b.getStamp().getTime()) {
+            return +1;
+         }
+      });
+
+      for (let i = indexMessageArray.length-1;i>=0;i--)
+      {
+         if (indexMessageArray[i].getStamp().getTime()<message.getStamp().getTime())
+         {
+            if (i-1>0)
+            {
+               message.setNext(indexMessageArray[i]);
+            }
+            else
+            {
+               message.setNext(undefined);
+            }
+
+            if (i+1<indexMessageArray.length)
+            {
+               indexMessageArray[i+1].setNext(message);
+            }
+            break;
+         }
+      }
+
+      this.firstMessage = indexMessageArray[indexMessageArray.length-1];
+
+      this.addMessage(message);
+
+      this.contact.setLastMessageDate(message.getStamp());
+
+      this.properties.set('firstMessageId', this.firstMessage.getUid());
+   }
+
    public unshiftMessage(message: IMessage) {
       let lastMessage = this.getLastMessage();
 

--- a/src/connection/AbstractConnection.ts
+++ b/src/connection/AbstractConnection.ts
@@ -313,6 +313,63 @@ abstract class AbstractConnection {
       return this.sendIQ(iq);
    }
 
+   public queryArchiveSync(
+      startDate: Date,
+      archive: JID,
+      version: string,
+      queryId: string,
+      withJID: string
+   ): Promise<Element> {
+      let iq = $iq({
+         type: 'set',
+         to: archive.bare,
+      });
+
+      iq.c('query', {
+         xmlns: version,
+         queryid: queryId,
+      });
+
+      iq.c('x', {
+         xmlns: 'jabber:x:data',
+         type: 'submit',
+      });
+
+      iq.c('field', {
+         var: 'FORM_TYPE',
+         type: 'hidden',
+      })
+         .c('value')
+         .t(version)
+         .up()
+         .up();
+
+      iq.c('field', {
+         var: 'start',
+      })
+         .c('value')
+         .t(startDate.toISOString())
+         .up()
+         .up();
+
+      iq.c('field', {
+         var: 'with',
+      })
+         .c('value')
+         .t(withJID)
+         .up()
+         .up();
+
+      iq.up()
+         .c('set', {
+            xmlns: 'http://jabber.org/protocol/rsm',
+         });
+
+      iq.up();
+
+      return this.sendIQ(iq);
+   }
+
    public changePassword(newPassword: string): Promise<Element> {
       let iq = $iq({
          type: 'set',

--- a/src/connection/Connection.interface.ts
+++ b/src/connection/Connection.interface.ts
@@ -58,6 +58,14 @@ export interface IConnection {
       end?: Date
    ): Promise<Element>;
 
+   queryArchiveSync(
+      startDate:Date,
+      archive: IJID,
+      version: string,
+      queryId: string,
+      withJID: string
+   ): Promise<Element>;
+
    changePassword(newPassword: string): Promise<Element>;
 
    close();

--- a/src/plugins/mam/Plugin.ts
+++ b/src/plugins/mam/Plugin.ts
@@ -58,6 +58,25 @@ export default class MessageArchiveManagementPlugin extends AbstractPlugin {
          this.addLoadButtonIfEnabled(chatWindow, contact);
       });
 
+      pluginAPI.registerConnectionHook((status:number, condition: string)=>{
+
+         if (status===8)
+         {
+            let interval = setInterval(()=>{ //check for contacts. if contacts were found we dont need to synchronize a second time.
+               let contacts = pluginAPI.getContactManager().getContacts();
+               if (contacts)
+               {
+                  for (let strcontact in contacts)
+                  {
+                     let archive = this.getArchive(contacts[strcontact].getJid());
+                     archive.lastMessages();
+                  }
+                  clearInterval(interval);
+               }
+            },1000);
+         }
+      });
+
       pluginAPI.registerChatWindowClearedHook((chatWindow: ChatWindow, contact: Contact) => {
          let archiveJid = this.getArchiveJid(contact);
 


### PR DESCRIPTION
This PR will fix (when finished) an issue of loading messages from mam: 
Case: if you are in an conversation with jsxc and logout and then continue the conversation with an other client or another instance of jsxc with other storage and then relogin with the instance mentioned before, then jsxc wont load the newly written messages from mam.
This PR will add the ability to sync all contacts after login and takes the last message timestamp as the beginning for them mam request.
It is only needed one time after login.